### PR TITLE
Add product categories, stock handling and order history

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -2,6 +2,7 @@
 namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Product;
+use App\Models\Category;
 use Illuminate\Http\Request;
 
 class ProductController extends Controller {
@@ -13,27 +14,33 @@ class ProductController extends Controller {
         return view('admin.products.index', compact('products'));
     }
     public function create(){
-        return view('admin.products.create');
+        $categories = Category::all();
+        return view('admin.products.create', compact('categories'));
     }
     public function store(Request $req){
         $data = $req->validate([
-            'name'=>'required',
-            'description'=>'nullable',
-            'price'=>'required|numeric',
-            'image'=>'nullable|url'
+            'name' => 'required',
+            'description' => 'nullable',
+            'price' => 'required|numeric',
+            'image' => 'nullable|url',
+            'stock' => 'required|integer|min:0',
+            'category_id' => 'nullable|exists:categories,id'
         ]);
         Product::create($data);
         return redirect()->route('admin.products.index')->with('success','Produk dibuat');
     }
     public function edit(Product $product){
-        return view('admin.products.edit', compact('product'));
+        $categories = Category::all();
+        return view('admin.products.edit', compact('product','categories'));
     }
     public function update(Request $req, Product $product){
         $data = $req->validate([
-            'name'=>'required',
-            'description'=>'nullable',
-            'price'=>'required|numeric',
-            'image'=>'nullable|url'
+            'name' => 'required',
+            'description' => 'nullable',
+            'price' => 'required|numeric',
+            'image' => 'nullable|url',
+            'stock' => 'required|integer|min:0',
+            'category_id' => 'nullable|exists:categories,id'
         ]);
         $product->update($data);
         return redirect()->route('admin.products.index')->with('success','Produk diperbarui');

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -2,6 +2,7 @@
 namespace App\Http\Controllers;
 use App\Models\Order;
 use App\Models\OrderItem;
+use App\Models\Product;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -15,8 +16,9 @@ class CheckoutController extends Controller {
         if(!$cart) return redirect()->route('products.index');
         $total = collect($cart)->sum(fn($item)=> $item['price'] * $item['quantity']);
         $order = Order::create([
-            'user_id'=>Auth::id(),
-            'total'=>$total
+            'user_id' => Auth::id(),
+            'total' => $total,
+            'status' => 'paid'
         ]);
         foreach($cart as $id=>$item){
             OrderItem::create([
@@ -25,6 +27,7 @@ class CheckoutController extends Controller {
                 'quantity'=>$item['quantity'],
                 'price'=>$item['price']
             ]);
+            Product::where('id', $id)->decrement('stock', $item['quantity']);
         }
         session()->forget('cart');
         return view('checkout.success', compact('order'));

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -2,21 +2,31 @@
 namespace App\Http\Controllers;
 
 use App\Models\Product;
+use App\Models\Category;
 use Illuminate\Http\Request;
 
 class ProductController extends Controller
 {
     // List products with toolbar
-    public function index()
+    public function index(Request $request)
     {
-        $products = Product::latest()->paginate(12);
-        return view('products.index', compact('products'));
+        $query = Product::query()->with('category');
+        if ($search = $request->query('search')) {
+            $query->where('name', 'like', "%{$search}%");
+        }
+        if ($category = $request->query('category')) {
+            $query->where('category_id', $category);
+        }
+        $products = $query->latest()->paginate(12)->withQueryString();
+        $categories = Category::all();
+        return view('products.index', compact('products','categories','search','category'));
     }
 
     // Show create form
     public function create()
     {
-        return view('products.create');
+        $categories = Category::all();
+        return view('products.create', compact('categories'));
     }
 
     // Store new product
@@ -27,6 +37,8 @@ class ProductController extends Controller
             'description' => 'nullable|string',
             'price'       => 'required|numeric|min:0',
             'image'       => 'nullable|url',
+            'stock'       => 'required|integer|min:0',
+            'category_id' => 'nullable|exists:categories,id',
         ]);
 
         Product::create($data);

--- a/app/Http/Controllers/UserOrderController.php
+++ b/app/Http/Controllers/UserOrderController.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use Illuminate\Support\Facades\Auth;
+
+class UserOrderController extends Controller
+{
+    public function index()
+    {
+        $orders = Order::with('items.product')->where('user_id', Auth::id())->latest()->paginate(10);
+        return view('profile.orders', compact('orders'));
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function products()
+    {
+        return $this->hasMany(Product::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -8,5 +8,10 @@ class Product extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'description', 'price', 'image'];
+    protected $fillable = ['name', 'description', 'price', 'image', 'stock', 'category_id'];
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
 }

--- a/database/migrations/2025_07_07_000003_create_categories_table.php
+++ b/database/migrations/2025_07_07_000003_create_categories_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_07_07_000004_add_category_id_to_products_table.php
+++ b/database/migrations/2025_07_07_000004_add_category_id_to_products_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('category_id');
+        });
+    }
+};

--- a/database/migrations/2025_07_07_000005_add_stock_to_products_table.php
+++ b/database/migrations/2025_07_07_000005_add_stock_to_products_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->integer('stock')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('stock');
+        });
+    }
+};

--- a/resources/views/admin/products/create.blade.php
+++ b/resources/views/admin/products/create.blade.php
@@ -7,6 +7,16 @@
   <div><label>Deskripsi</label><textarea name="description"></textarea></div>
   <div><label>Harga</label><input type="number" name="price" step="0.01"></div>
   <div><label>Image URL</label><input type="text" name="image"></div>
+  <div><label>Stok</label><input type="number" name="stock" min="0" value="0"></div>
+  <div>
+    <label>Kategori</label>
+    <select name="category_id">
+      <option value="">-</option>
+      @foreach($categories as $c)
+        <option value="{{ $c->id }}">{{ $c->name }}</option>
+      @endforeach
+    </select>
+  </div>
   <button class="bg-green-600 text-white px-4 py-2 rounded">Simpan</button>
 </form>
 @endsection

--- a/resources/views/admin/products/edit.blade.php
+++ b/resources/views/admin/products/edit.blade.php
@@ -7,6 +7,16 @@
   <div><label>Deskripsi</label><textarea name="description">{{ $product->description }}</textarea></div>
   <div><label>Harga</label><input type="number" name="price" step="0.01" value="{{ $product->price }}"></div>
   <div><label>Image URL</label><input type="text" name="image" value="{{ $product->image }}"></div>
+  <div><label>Stok</label><input type="number" name="stock" min="0" value="{{ $product->stock }}"></div>
+  <div>
+    <label>Kategori</label>
+    <select name="category_id">
+      <option value="">-</option>
+      @foreach($categories as $c)
+        <option value="{{ $c->id }}" @selected($c->id == $product->category_id)>{{ $c->name }}</option>
+      @endforeach
+    </select>
+  </div>
   <button class="bg-green-600 text-white px-4 py-2 rounded">Update</button>
 </form>
 @endsection

--- a/resources/views/admin/products/index.blade.php
+++ b/resources/views/admin/products/index.blade.php
@@ -3,12 +3,14 @@
 <h1 class="text-3xl mb-6">Kelola Produk</h1>
 <a href="{{ route('admin.products.create') }}" class="bg-green-600 text-white px-4 py-2 rounded mb-4 inline-block">Tambah Produk</a>
 <table class="w-full bg-white rounded shadow">
-  <thead><tr class="bg-gray-100"><th>ID</th><th>Nama</th><th>Harga</th><th>Aksi</th></tr></thead>
+  <thead><tr class="bg-gray-100"><th>ID</th><th>Nama</th><th>Kategori</th><th>Stok</th><th>Harga</th><th>Aksi</th></tr></thead>
   <tbody>
     @foreach($products as $p)
       <tr>
         <td class="p-2">{{ $p->id }}</td>
         <td class="p-2">{{ $p->name }}</td>
+        <td class="p-2">{{ $p->category?->name ?? '-' }}</td>
+        <td class="p-2">{{ $p->stock }}</td>
         <td class="p-2">Rp {{ number_format($p->price,0,',','.') }}</td>
         <td class="p-2">
           <a href="{{ route('admin.products.edit', $p) }}">Edit</a>

--- a/resources/views/checkout/success.blade.php
+++ b/resources/views/checkout/success.blade.php
@@ -3,6 +3,7 @@
   <div class="bg-white p-6 rounded shadow text-center">
     <h2 class="text-2xl mb-4">Pesanan Berhasil!</h2>
     <p>Order ID: <span class="font-mono">{{ $order->id }}</span></p>
+    <p>Status: {{ ucfirst($order->status) }}</p>
     <p>Total: Rp {{ number_format($order->total,0,',','.') }}</p>
     <a href="{{ route('products.index') }}" class="mt-4 inline-block bg-indigo-600 text-white px-4 py-2 rounded">Lanjut Belanja</a>
   </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -37,6 +37,9 @@
                         <x-dropdown-link :href="route('profile.edit')">
                             {{ __('Profile') }}
                         </x-dropdown-link>
+                        <x-dropdown-link :href="route('orders.index')">
+                            {{ __('Orders') }}
+                        </x-dropdown-link>
 
                         <!-- Authentication -->
                         <form method="POST" action="{{ route('logout') }}">
@@ -82,6 +85,9 @@
             <div class="mt-3 space-y-1">
                 <x-responsive-nav-link :href="route('profile.edit')">
                     {{ __('Profile') }}
+                </x-responsive-nav-link>
+                <x-responsive-nav-link :href="route('orders.index')">
+                    {{ __('Orders') }}
                 </x-responsive-nav-link>
 
                 <!-- Authentication -->

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -32,6 +32,19 @@
         <input type="text" name="image" value="{{ old('image') }}"
                class="w-full border rounded px-3 py-2" />
       </div>
+      <div>
+        <label class="block text-gray-700">Stock</label>
+        <input type="number" name="stock" value="{{ old('stock',0) }}" min="0" class="w-full border rounded px-3 py-2" />
+      </div>
+      <div>
+        <label class="block text-gray-700">Category</label>
+        <select name="category_id" class="w-full border rounded px-3 py-2">
+          <option value="">-</option>
+          @foreach($categories as $c)
+            <option value="{{ $c->id }}" @selected(old('category_id')==$c->id)>{{ $c->name }}</option>
+          @endforeach
+        </select>
+      </div>
       <button type="submit"
               class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-500">
         Add Product

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -12,6 +12,17 @@
     @endauth
   </div>
 
+  <form method="GET" class="mb-6 flex space-x-2">
+    <input type="text" name="search" value="{{ $search ?? '' }}" placeholder="Search" class="border rounded px-2 py-1">
+    <select name="category" class="border rounded px-2 py-1">
+      <option value="">All Categories</option>
+      @foreach($categories as $c)
+        <option value="{{ $c->id }}" @selected(($category ?? '')==$c->id)>{{ $c->name }}</option>
+      @endforeach
+    </select>
+    <button class="bg-indigo-600 text-white px-4 rounded">Filter</button>
+  </form>
+
   <div class="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
     @foreach($products as $product)
       <div class="bg-white p-4 rounded-lg shadow hover:shadow-lg transition">

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -7,13 +7,13 @@
       <img src="{{ $product->image ?? 'https://via.placeholder.com/600x400' }}" alt="{{ $product->name }}" class="w-full md:w-1/2 h-auto object-cover rounded">
       <div class="mt-6 md:mt-0 md:ml-6 flex-1">
         <h1 class="text-3xl font-bold">{{ $product->name }}</h1>
+        <p class="text-sm text-gray-500">Kategori: {{ $product->category?->name ?? '-' }}</p>
         <p class="mt-4 text-gray-700">{{ $product->description }}</p>
         <p class="mt-6 text-2xl font-bold text-indigo-600">Rp {{ number_format($product->price,0,',','.') }}</p>
-        <form action="#" method="POST" class="mt-6">
+        <p class="mt-2">Stok: {{ $product->stock }}</p>
+        <form action="{{ route('cart.add', $product) }}" method="POST" class="mt-6">
           @csrf
-          <button type="button" disabled class="bg-green-600 text-white px-6 py-3 rounded cursor-not-allowed">
-            Add to Cart
-          </button>
+          <button class="bg-green-600 text-white px-6 py-3 rounded">Add to Cart</button>
         </form>
       </div>
     </div>

--- a/resources/views/profile/orders.blade.php
+++ b/resources/views/profile/orders.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+@section('content')
+<div class="container mx-auto py-8">
+  <h1 class="text-2xl font-bold mb-4">Riwayat Pesanan</h1>
+  <table class="w-full bg-white rounded shadow">
+    <thead>
+      <tr class="bg-gray-100"><th>ID</th><th>Status</th><th>Total</th><th>Tanggal</th></tr>
+    </thead>
+    <tbody>
+      @foreach($orders as $o)
+        <tr>
+          <td class="p-2">{{ $o->id }}</td>
+          <td class="p-2">{{ ucfirst($o->status) }}</td>
+          <td class="p-2">Rp {{ number_format($o->total,0,',','.') }}</td>
+          <td class="p-2">{{ $o->created_at->format('d/m/Y H:i') }}</td>
+        </tr>
+      @endforeach
+    </tbody>
+  </table>
+  <div class="mt-4">{{ $orders->links() }}</div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,11 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\UserOrderController;
+use App\Http\Controllers\Admin\ProductController as AdminProductController;
+use App\Http\Controllers\Admin\OrderController as AdminOrderController;
+use App\Http\Controllers\CartController;
+use App\Http\Controllers\CheckoutController;
 
 // Auth routes
 require __DIR__.'/auth.php';
@@ -14,11 +19,27 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
 
+    // Order history
+    Route::get('/orders', [UserOrderController::class, 'index'])->name('orders.index');
+
     // Product management
     Route::get('/products/create', [ProductController::class, 'create'])->name('products.create');
     Route::post('/products', [ProductController::class, 'store'])->name('products.store');
 });
 
+// Admin routes
+Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
+    Route::resource('products', AdminProductController::class)->except(['show']);
+    Route::get('orders', [AdminOrderController::class, 'index'])->name('orders.index');
+});
+
 // Public product catalog
 Route::get('/products', [ProductController::class, 'index'])->name('products.index');
 Route::get('/products/{product}', [ProductController::class, 'show'])->name('products.show');
+
+// Cart & Checkout
+Route::get('/cart', [CartController::class, 'index'])->name('cart.index');
+Route::post('/cart/add/{product}', [CartController::class, 'add'])->name('cart.add');
+Route::post('/cart/remove/{id}', [CartController::class, 'remove'])->name('cart.remove');
+Route::get('/checkout', [CheckoutController::class, 'index'])->name('checkout.index');
+Route::post('/checkout', [CheckoutController::class, 'process'])->name('checkout.process');


### PR DESCRIPTION
## Summary
- add `Category` model and migrations for categories and product stock
- adjust product model for `stock` and `category_id`
- extend admin product management to handle stock and categories
- allow searching and filtering products by category
- display stock info and category on product pages
- add cart and checkout routes and decrement stock on purchase
- mark orders as paid and show user order history
- define admin routes with prefix
- fix missing request parameter in product index

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e820766148323971c1ddb149a7457